### PR TITLE
switch from feign client to restclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A pure Java core library for calculating Qibla direction. This module will provi
 ### prayingtimes-models
 A Java package containing POJO (Plain Old Java Object) classes used across the application for API data transfer and internal processing.
 
+mvn clean install -pl prayingtimes-models -am
+
 ### prayingtimes-timeskeeper
 A Spring Boot application with REST API endpoints for calculating prayer times.
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 
         <!-- Dependency versions -->
         <spring-boot.version>4.0.3</spring-boot.version>
-        <spring-cloud.version>2025.1.1</spring-cloud.version>
         <lombok.version>1.18.44</lombok.version>
         <junit.version>6.0.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
@@ -65,13 +64,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/prayingtimes-telegrambot/Dockerfile
+++ b/prayingtimes-telegrambot/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/amazoncorretto:25-alpine
+FROM docker.io/library/amazoncorretto:26-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=target/*.jar

--- a/prayingtimes-telegrambot/pom.xml
+++ b/prayingtimes-telegrambot/pom.xml
@@ -24,10 +24,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/Main.java
+++ b/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/Main.java
@@ -6,11 +6,9 @@ package ru.mfilatov.prayingtimes.telegrambot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EnableFeignClients
 @EnableJpaRepositories
 public class Main {
 

--- a/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
+++ b/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
@@ -111,7 +111,7 @@ public class PrayingTimesAzanBot
       user.setLatitude(update.getMessage().getLocation().getLatitude());
       user.setLongitude(update.getMessage().getLocation().getLongitude());
 
-      var timezone = locationClient.getTimes(user.getLatitude(), user.getLongitude());
+      var timezone = locationClient.getTimezone(user.getLatitude(), user.getLongitude());
       if (Objects.nonNull(timezone.getBody())) {
         user.setTimezone(timezone.getBody().timezone());
       }

--- a/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/clients/LocationClient.java
+++ b/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/clients/LocationClient.java
@@ -4,17 +4,34 @@
 */
 package ru.mfilatov.prayingtimes.telegrambot.clients;
 
-import jakarta.validation.Valid;
-import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 import ru.mfilatov.prayingtimes.models.dto.TimezoneResponse;
 
-@FeignClient(value = "locationClient", url = "${api.location.url:localhost:8080/api/location}")
-public interface LocationClient {
-  @GetMapping(path = "/timezone")
-  ResponseEntity<TimezoneResponse> getTimes(
-      @RequestParam(value = "latitude") @Valid Double latitude,
-      @RequestParam(value = "longitude") @Valid Double longitude);
+@Component
+public class LocationClient {
+
+  private final RestClient restClient;
+
+  public LocationClient(
+      RestClient.Builder restClientBuilder,
+      @Value("${api.location.url:localhost:8080/api/location}") String baseUrl) {
+    this.restClient = restClientBuilder.baseUrl(baseUrl).build();
+  }
+
+  public ResponseEntity<TimezoneResponse> getTimezone(Double latitude, Double longitude) {
+    return restClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path("/timezone")
+                    .queryParam("latitude", latitude)
+                    .queryParam("longitude", longitude)
+                    .build())
+        .retrieve()
+        .toEntity(TimezoneResponse.class);
+  }
 }

--- a/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/clients/TimesClient.java
+++ b/prayingtimes-telegrambot/src/main/java/ru/mfilatov/prayingtimes/telegrambot/clients/TimesClient.java
@@ -4,23 +4,43 @@
 */
 package ru.mfilatov.prayingtimes.telegrambot.clients;
 
-import jakarta.validation.Valid;
-import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 import ru.mfilatov.prayingtimes.models.PrayerTimes;
 import ru.mfilatov.prayingtimes.models.PrayerTimesCalculationMethod;
 
-@FeignClient(
-    value = "timeskeeperClient",
-    url = "${api.timeskeeper.url:localhost:8080/api/prayer-times}")
-public interface TimesClient {
-  @GetMapping(path = "/getTimes")
-  ResponseEntity<PrayerTimes> getTimes(
-      @RequestParam(value = "date") @Valid String date,
-      @RequestParam(value = "latitude") @Valid Double latitude,
-      @RequestParam(value = "longitude") @Valid Double longitude,
-      @RequestParam(value = "method") PrayerTimesCalculationMethod method,
-      @RequestParam(value = "timezone") String timezone);
+@Component
+public class TimesClient {
+
+  private final RestClient restClient;
+
+  public TimesClient(
+      RestClient.Builder restClientBuilder,
+      @Value("${api.timeskeeper.url:localhost:8080/api/prayer-times}") String baseUrl) {
+    this.restClient = restClientBuilder.baseUrl(baseUrl).build();
+  }
+
+  public ResponseEntity<PrayerTimes> getTimes(
+      String date,
+      Double latitude,
+      Double longitude,
+      PrayerTimesCalculationMethod method,
+      String timezone) {
+    return restClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path("/getTimes")
+                    .queryParam("date", date)
+                    .queryParam("latitude", latitude)
+                    .queryParam("longitude", longitude)
+                    .queryParam("method", method.name())
+                    .queryParam("timezone", timezone)
+                    .build())
+        .retrieve()
+        .toEntity(PrayerTimes.class);
+  }
 }

--- a/prayingtimes-timeskeeper/Dockerfile
+++ b/prayingtimes-timeskeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/amazoncorretto:26.0.0-alpine
+FROM docker.io/library/amazoncorretto:26-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=target/*.jar

--- a/prayingtimes-timeskeeper/pom.xml
+++ b/prayingtimes-timeskeeper/pom.xml
@@ -24,10 +24,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
@@ -74,8 +70,14 @@
 
         <dependency>
             <groupId>ru.mfilatov.prayingtimes</groupId>
+            <artifactId>prayingtimes-models</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.mfilatov.prayingtimes</groupId>
             <artifactId>prayingtimes-time-calculator</artifactId>
             <version>1.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/Main.java
+++ b/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/Main.java
@@ -6,10 +6,8 @@ package ru.mfilatov.prayingtimes.timecalculator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableFeignClients
 public class Main {
 
   public static void main(String[] args) {

--- a/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/clients/AladhanRestApiClient.java
+++ b/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/clients/AladhanRestApiClient.java
@@ -4,29 +4,78 @@
 */
 package ru.mfilatov.prayingtimes.timecalculator.clients;
 
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 import ru.mfilatov.prayingtimes.timecalculator.model.aladhan.AladhanResponse;
 
-@FeignClient(
-    name = "aladhanApiClient",
-    url = "${aladhan.api.base-url:https://api.aladhan.com/v1/timings}")
-public interface AladhanRestApiClient {
-  @GetMapping(path = "/{date}")
-  AladhanResponse getPrayerTimes(
-      @PathVariable("date") String date,
-      @RequestParam(value = "latitude") String latitude,
-      @RequestParam(value = "longitude") String longitude,
-      @RequestParam(value = "method", required = false) Integer method,
-      @RequestParam(value = "shafaq", required = false) String shafaq,
-      @RequestParam(value = "tune", required = false) String tune,
-      @RequestParam(value = "school", required = false) Integer school,
-      @RequestParam(value = "midnightMode", required = false) Integer midnightMode,
-      @RequestParam(value = "timezonestring", required = false) String timezonestring,
-      @RequestParam(value = "latitudeAdjustmentMethod", required = false)
-          Integer latitudeAdjustmentMethod,
-      @RequestParam(value = "calendarMethod", required = false) String calendarMethod,
-      @RequestParam(value = "iso8601", required = false) Boolean iso8601);
+@Component
+public class AladhanRestApiClient {
+
+  private final RestClient restClient;
+
+  public AladhanRestApiClient(
+      RestClient.Builder restClientBuilder,
+      @Value("${aladhan.api.base-url:https://api.aladhan.com/v1/timings}") String baseUrl) {
+    this.restClient = restClientBuilder.baseUrl(baseUrl).build();
+  }
+
+  public AladhanResponse getPrayerTimes(
+      String date,
+      String latitude,
+      String longitude,
+      Integer method,
+      String shafaq,
+      String tune,
+      Integer school,
+      Integer midnightMode,
+      String timezonestring,
+      Integer latitudeAdjustmentMethod,
+      String calendarMethod,
+      Boolean iso8601) {
+    return restClient
+        .get()
+        .uri(
+            uriBuilder -> {
+              var builder = uriBuilder.path("/" + date);
+
+              if (latitude != null) {
+                builder.queryParam("latitude", latitude);
+              }
+              if (longitude != null) {
+                builder.queryParam("longitude", longitude);
+              }
+              if (method != null) {
+                builder.queryParam("method", method);
+              }
+              if (shafaq != null) {
+                builder.queryParam("shafaq", shafaq);
+              }
+              if (tune != null) {
+                builder.queryParam("tune", tune);
+              }
+              if (school != null) {
+                builder.queryParam("school", school);
+              }
+              if (midnightMode != null) {
+                builder.queryParam("midnightMode", midnightMode);
+              }
+              if (timezonestring != null) {
+                builder.queryParam("timezonestring", timezonestring);
+              }
+              if (latitudeAdjustmentMethod != null) {
+                builder.queryParam("latitudeAdjustmentMethod", latitudeAdjustmentMethod);
+              }
+              if (calendarMethod != null) {
+                builder.queryParam("calendarMethod", calendarMethod);
+              }
+              if (iso8601 != null) {
+                builder.queryParam("iso8601", iso8601);
+              }
+
+              return builder.build();
+            })
+        .retrieve()
+        .body(AladhanResponse.class);
+  }
 }

--- a/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/clients/OpenStreetMapSearchClient.java
+++ b/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/clients/OpenStreetMapSearchClient.java
@@ -5,19 +5,40 @@
 package ru.mfilatov.prayingtimes.timecalculator.clients;
 
 import java.util.List;
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 import ru.mfilatov.prayingtimes.timecalculator.model.openstreetmap.SearchJsonV2;
 
-@FeignClient(
-    value = "openStreetMapSearchClient",
-    url = "${location.api.base-url:https://nominatim.openstreetmap.org/}")
-public interface OpenStreetMapSearchClient {
+@Component
+public class OpenStreetMapSearchClient {
 
-  @GetMapping(path = "search")
-  List<SearchJsonV2> getCityLocation(
-      @RequestParam(value = "city") String city,
-      @RequestParam(value = "country") String country,
-      @RequestParam(value = "format") String format);
+  private final RestClient restClient;
+
+  public OpenStreetMapSearchClient(
+      RestClient.Builder restClientBuilder,
+      @Value("${location.api.base-url:https://nominatim.openstreetmap.org/}") String baseUrl,
+      @Value(
+              "${location.api.user-agent:PrayingTimesApp/1.0 (https://github.com/map7000/prayingtimes)}")
+          String userAgent) {
+    this.restClient =
+        restClientBuilder.baseUrl(baseUrl).defaultHeader(HttpHeaders.USER_AGENT, userAgent).build();
+  }
+
+  public List<SearchJsonV2> getCityLocation(String city, String country, String format) {
+    return restClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path("search")
+                    .queryParam("city", city)
+                    .queryParam("country", country)
+                    .queryParam("format", format)
+                    .build())
+        .retrieve()
+        .body(new ParameterizedTypeReference<>() {});
+  }
 }

--- a/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/config/RestClientConfig.java
+++ b/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/config/RestClientConfig.java
@@ -6,12 +6,13 @@ package ru.mfilatov.prayingtimes.timecalculator.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tools.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
 
 @Configuration
-public class JacksonConfig {
+public class RestClientConfig {
+
   @Bean
-  public ObjectMapper objectMapper() {
-    return new ObjectMapper();
+  public RestClient.Builder restClientBuilder() {
+    return RestClient.builder();
   }
 }

--- a/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/exception/GlobalExceptionHandler.java
+++ b/prayingtimes-timeskeeper/src/main/java/ru/mfilatov/prayingtimes/timecalculator/exception/GlobalExceptionHandler.java
@@ -4,17 +4,23 @@
 */
 package ru.mfilatov.prayingtimes.timecalculator.exception;
 
-import feign.FeignException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  @ExceptionHandler(FeignException.class)
-  public ResponseEntity<String> handleFeignException(FeignException ex) {
-    return ResponseEntity.status(ex.status()).body("API error: " + ex.getMessage());
+  @ExceptionHandler(HttpStatusCodeException.class)
+  public ResponseEntity<String> handleHttpStatusCodeException(HttpStatusCodeException ex) {
+    return ResponseEntity.status(ex.getStatusCode()).body("API error: " + ex.getMessage());
+  }
+
+  @ExceptionHandler(ResourceAccessException.class)
+  public ResponseEntity<String> handleResourceAccessException(ResourceAccessException ex) {
+    return ResponseEntity.status(503).body("Service unavailable: " + ex.getMessage());
   }
 
   @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
Switch from Feign Client to Spring RestClient

    Summary
    This PR migrates the HTTP client implementation from OpenFeign to Spring's RestClient. This change simplifies the HTTP client configuration and reduces external dependencies.

    Core Changes
     - Replaced Feign clients with Spring RestClient in prayingtimes-timeskeeper and prayingtimes-telegrambot modules
     - Updated `OpenStreetMapSearchClient`:
       - Added proper User-Agent header to comply with OpenStreetMap Nominatim API requirements
     - Updated `AladhanRestApiClient` - Migrated from Feign interface to RestClient implementation

    Dependency Changes
     - Removed spring-cloud-starter-openfeign dependency
     - Removed spring-boot-starter-webflux (no longer needed without Feign)
     
